### PR TITLE
Fix angular/angular.dart.tutorial#132

### DIFF
--- a/site/tutorial/08-ch06-view.markdown
+++ b/site/tutorial/08-ch06-view.markdown
@@ -186,7 +186,6 @@ class SearchRecipeComponent {
   Map<String, bool> get categoryFilterMap => _categoryFilterMap;
   void set categoryFilterMap(values) {
     _categoryFilterMap = values;
-    _categories = categoryFilterMap.keys.toList();
     _categories.addAll(categoryFilterMap.keys);
   }
 

--- a/site/tutorial/08-ch06-view.markdown
+++ b/site/tutorial/08-ch06-view.markdown
@@ -175,8 +175,8 @@ right excerpt in the table above).</p>
     selector: 'search-recipe',
     templateUrl: 'search_recipe.html')
 class SearchRecipeComponent {
-  Map<String, bool> _categoryFilterMap;
-  List<String> _categories;
+  Map<String, bool> _categoryFilterMap = {};
+  List<String> _categories = [];
   List<String> get categories => _categories;
 
   @NgTwoWay('name-filter-string')
@@ -187,6 +187,7 @@ class SearchRecipeComponent {
   void set categoryFilterMap(values) {
     _categoryFilterMap = values;
     _categories = categoryFilterMap.keys.toList();
+    _categories.addAll(categoryFilterMap.keys);
   }
 
   void clearFilters() {


### PR DESCRIPTION
The cause of this bug is that _categories = categoryFilterMap.keys.toList()
gives back a set with the same values every time, but not the same
*instances* of the set every time. In Dart, Set equality is shallow, or instance
equality, so Angular thinks that it is getting back brand new data every time
it calls the categories getter.

With categories.addAll(categoryFilterMap.keys), the categories getter returns
the same instance each time.

There will be a similar fix in angular.dart.tutorial to update the tutorial's
Dart code.