### PR TITLE
Fix angular/angular.dart.tutorial#132

### DIFF
--- a/site/tutorial/08-ch06-view.markdown
+++ b/site/tutorial/08-ch06-view.markdown
@@ -176,8 +176,8 @@ right excerpt in the table above).</p>
     templateUrl: 'search_recipe.html')
 class SearchRecipeComponent {
   Map<String, bool> _categoryFilterMap = {};
-  List<String> _categories = [];
-  List<String> get categories => _categories;
+  final List<String> categories = [];
+
 
   @NgTwoWay('name-filter-string')
   String nameFilterString = "";
@@ -186,7 +186,8 @@ class SearchRecipeComponent {
   Map<String, bool> get categoryFilterMap => _categoryFilterMap;
   void set categoryFilterMap(values) {
     _categoryFilterMap = values;
-    _categories.addAll(categoryFilterMap.keys);
+    categories.clear();
+    categories.addAll(categoryFilterMap.keys);
   }
 
   void clearFilters() {


### PR DESCRIPTION
Use final fields instead of private fields with public getters.
To avoid a potential bug, in set categoryFilterMap(values) the categories
list probably needs to be cleared before addAll is called.