### PR TITLE
Fix error in 06-ch04-directive.markdown

### DIFF
--- a/site/tutorial/06-ch04-directive.markdown
+++ b/site/tutorial/06-ch04-directive.markdown
@@ -68,8 +68,8 @@ ways:</p>
   <a href="https://github.com/angular/angular.dart.tutorial/blob/master/Chapter_04/web/main.dart">
     web/main.dart</a> to register the <code>Tooltip</code> type.</li>
 <li>Modifying
-  <a href="https://github.com/angular/angular.dart.tutorial/blob/master/Chapter_04/web/index.html">
-    web/index.html</a> to use the tooltip decorator.</li>
+  <a href="https://github.com/angular/angular.dart.tutorial/blob/master/Chapter_04/lib/component/recipe_book.html">
+    lib/component/recipe_book.html</a> to use the tooltip decorator.</li>
 </ul>
 
 <hr class="spacer" />


### PR DESCRIPTION
To use the tooltip, web/index.html does not need to be touched. It's recipe_book.html that's updated instead.